### PR TITLE
Ensure model dump directory exists

### DIFF
--- a/ml/train_from_db.py
+++ b/ml/train_from_db.py
@@ -1,6 +1,13 @@
-from sklearn.linear_model import LinearRegression
+from pathlib import Path
+
+import joblib
 import numpy as np
+from sklearn.linear_model import LinearRegression
+
 from models import Product
+
+
+MODEL_PATH = Path(__file__).resolve().parent / "model_dump" / "model.joblib"
 
 
 def train_model(db):
@@ -14,4 +21,8 @@ def train_model(db):
 
     model = LinearRegression()
     model.fit(x, y)
+
+    MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, MODEL_PATH)
+
     return model


### PR DESCRIPTION
## Summary
- change the persisted model location to a dedicated `model_dump/model.joblib` path
- create the parent directory before saving so serialization succeeds reliably

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6ecda7148832dbc4c9d24a041c942